### PR TITLE
Sld

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,8 @@ version: '3.3'
 services:
   fastapi:
     image: registry.met.no/s-enda/data-visualization-services/container-fastapi:main
+    build:
+      context: ./containers/fastapi
     environment:
         DEBUG: 1
         PYTHONUNBUFFERED: 1
@@ -14,6 +16,8 @@ services:
       - mapfiles:/app/static/mapfiles
     ports:
       - 8080:80
+
+
 
   mapserver:
     image: registry.met.no/s-enda/container-mapserver:latest

--- a/mapgen/main.py
+++ b/mapgen/main.py
@@ -22,6 +22,7 @@ MAX_PROCESSING_SECOND = 600
 
 
 def configure_routing():
+    app.mount("/static", StaticFiles(directory="/app/static"), name="static")
     app.include_router(redirect.router)
     app.include_router(dashboard.router)
 

--- a/mapgen/static/SLD/default.sld
+++ b/mapgen/static/SLD/default.sld
@@ -1,0 +1,41 @@
+<StyledLayerDescriptor xmlns="http://www.opengis.net/sld" xmlns:ogc="http://www.opengis.net/ogc" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.0.0" xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.0.0/StyledLayerDescriptor.xsd">
+    <NamedLayer>
+        <Name>world</Name>
+        <UserStyle>
+            <Title>red</Title>
+            <FeatureTypeStyle>
+                <Rule>
+                    <PolygonSymbolizer>
+                        <Geometry>
+                            <PropertyName>the_area</PropertyName>
+                        </Geometry>
+                        <Stroke>
+                            <CssParameter name="stroke">#ff0000</CssParameter>
+                        </Stroke>
+                        <Fill>
+                            <CssParameter name="fill">#ffaaaa</CssParameter>
+                        </Fill>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>borders</Name>
+        <UserStyle>
+            <Title>red</Title>
+                <FeatureTypeStyle>
+                <Rule>
+                    <LineSymbolizer>
+                        <Geometry>
+                            <PropertyName>center-line</PropertyName>
+                        </Geometry>
+                        <Stroke>
+                            <CssParameter name="stroke">#ff0000</CssParameter>
+                        </Stroke>
+                    </LineSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+</StyledLayerDescriptor>


### PR DESCRIPTION
**Summary**:

Add a SLD directory to store Style layer descriptor

SLD files can be served by fast API as static files and consumed by the mapserver `getMap` request as URL

**Related issue**:

Closes #22

**Suggested reviewer(s)**:

@TAlonglong @trondmm 

**Reviewer checklist**:

* [ ] The headers of all files contain a reference to the repository license
* [ ] 100% test coverage of new code - meaning:
  * [ ] The overall test coverage increased or remained the same as before
  * [ ] Every function is accompanied with a test suite
  * [ ] Tests are both positive (testing that the function work as intended with valid data) and negative (testing that the function behaves as expected with invalid data, e.g., that correct exceptions are thrown)
  * [ ] Functions with optional arguments have separate tests for all options
* [ ] Examples are supported by doctests
* [ ] All tests are passing
* [ ] All names (e.g., files, classes, functions, variables) are explicit
* [ ] Documentation (as docstrings) is complete and understandable

The checklist is based on the S-ENDA conventions and definition of done (see [General Conventions](https://s-enda-documentation.readthedocs.io/en/latest/general_conventions.html)). The above points are not necessarily relevant to all contributions. In that case, please add a short explanation to help the reviewer.